### PR TITLE
Support for std::string_view in proxy_base

### DIFF
--- a/include/sol/proxy_base.hpp
+++ b/include/sol/proxy_base.hpp
@@ -49,6 +49,11 @@ namespace sol {
 			return super.template get<std::string>();
 		}
 
+		operator std::string_view() const {
+			const Super& super = *static_cast<const Super*>(static_cast<const void*>(this));
+			return super.template get<std::string_view>();
+		}
+
 		template <typename T, meta::enable<meta::neg<meta::is_string_constructible<T>>, is_proxy_primitive<meta::unqualified_t<T>>> = meta::enabler>
 		operator T() const {
 			const Super& super = *static_cast<const Super*>(static_cast<const void*>(this));


### PR DESCRIPTION
Allows code like the following to work:
```cpp
std::string_view pretty_name = my_table["pretty_name"];
```

Otherwise it fails with:

```
error: conversion from ‘sol::table_proxy<sol::basic_table_core<false, sol::basic_reference<false> >&, std::tuple<const char (&)[12]> >’ to non-scalar type ‘std::string_view’ {aka ‘std::basic_string_view<char>’} requested
 2131 |                         std::string_view psvPrettyName = tTable["pretty_name"];
      |                                  
```